### PR TITLE
Object id can be array or MongoDB\Model\BSONDocument

### DIFF
--- a/src/Mandango/Extension/templates/Core/Query.php.twig
+++ b/src/Mandango/Extension/templates/Core/Query.php.twig
@@ -8,6 +8,7 @@
         $repository = $this->getRepository();
         $mandango = $repository->getMandango();
         $documentClass = $repository->getDocumentClass();
+        $identityMapObject = $repository->getIdentityMap();
         $identityMap =& $repository->getIdentityMap()->allByReference();
 {% if config_class.inheritable and 'single' == config_class.inheritable.type %}
         $identityMaps = array();
@@ -37,7 +38,7 @@
 
         $documents = array();
         foreach ($this->createCursor() as $data) {
-            $id = (string)$data['_id'];
+            $id = $identityMapObject->idToString($data['_id']);
 {% if config_class.inheritable and 'single' == config_class.inheritable.type %}
             $documentClass = null;
             $identityMap = null;

--- a/src/Mandango/Extension/templates/Core/Repository.php.twig
+++ b/src/Mandango/Extension/templates/Core/Repository.php.twig
@@ -93,6 +93,7 @@
             $documents = array($documents);
         }
 
+        $identityMapObject = $this->getIdentityMap();
         $identityMap =& $this->getIdentityMap()->allByReference();
         $collection = $this->getCollection();
 
@@ -145,7 +146,7 @@
                     $document->setId($data['_id']);
                     $document->setIsNew(false);
                     $document->clearModified();
-                    $identityMap[(string) $data['_id']] = $document;
+                    $identityMap[$identityMapObject->idToString($data['_id'])] = $document;
 {% if config_class._has_groups %}
                     $document->resetGroups();
 {% endif %}
@@ -191,7 +192,7 @@
                 $document->setId($data['_id']);
                 $document->setIsNew(false);
                 $document->clearModified();
-                $identityMap[(string) $data['_id']] = $document;
+                $identityMap[$identityMapObject->idToString($data['_id'])] = $document;
 
 {% if config_class._has_groups %}
                 $document->resetGroups();
@@ -293,9 +294,10 @@
 {% endfor %}
         }
 
+        $identityMapObject = $this->getIdentityMap();
         $identityMap =& $this->getIdentityMap()->allByReference();
         foreach ($documents as $document) {
-            unset($identityMap[(string) $document->getId()]);
+            unset($identityMap[$identityMapObject->idToString($document->getId())]);
             $document->setIsNew(true);
             $document->setId(null);
         }

--- a/src/Mandango/IdentityMap.php
+++ b/src/Mandango/IdentityMap.php
@@ -11,6 +11,8 @@
 
 namespace Mandango;
 
+use JsonSerializable;
+use InvalidArgumentException;
 use Mandango\Document\Document;
 
 /**
@@ -39,7 +41,7 @@ class IdentityMap implements IdentityMapInterface
      */
     public function set($id, Document $document)
     {
-        $this->documents[(string) $id] = $document;
+        $this->documents[$this->idToString($id)] = $document;
     }
 
     /**
@@ -47,7 +49,7 @@ class IdentityMap implements IdentityMapInterface
      */
     public function has($id)
     {
-        return isset($this->documents[(string) $id]);
+        return isset($this->documents[$this->idToString($id)]);
     }
 
     /**
@@ -55,7 +57,7 @@ class IdentityMap implements IdentityMapInterface
      */
     public function get($id)
     {
-        return $this->documents[(string) $id];
+        return $this->documents[$this->idToString($id)];
     }
 
     /**
@@ -79,7 +81,7 @@ class IdentityMap implements IdentityMapInterface
      */
     public function remove($id)
     {
-        unset($this->documents[(string) $id]);
+        unset($this->documents[$this->idToString($id)]);
     }
 
     /**
@@ -88,5 +90,27 @@ class IdentityMap implements IdentityMapInterface
     public function clear()
     {
         $this->documents = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function idToString($id)
+    {
+        if (is_object($id)) {
+            if (method_exists($id, '__toString')) {
+                return (string) $id;
+            }
+            if ($id instanceof JsonSerializable) { //MongoDB\Model\BSONDocument
+                return (string) json_encode($id);
+            }
+
+            throw new InvalidArgumentException('Invalid document id. Object has to have __toString or implements \JsonSerializable');
+        }
+        if (is_array($id)) {
+            return (string) json_encode($id);
+        }
+
+        return (string) $id;
     }
 }

--- a/src/Mandango/IdentityMapInterface.php
+++ b/src/Mandango/IdentityMapInterface.php
@@ -87,4 +87,13 @@ interface IdentityMapInterface
      * @api
      */
     function clear();
+
+    /**
+     * Convert id to string
+     *
+     * @param $id
+     *
+     * @return string
+     */
+    function idToString($id);
 }

--- a/src/Mandango/Repository.php
+++ b/src/Mandango/Repository.php
@@ -225,7 +225,7 @@ abstract class Repository
         $documents = array();
         foreach ($mongoIds as $id) {
             if ($this->identityMap->has($id)) {
-                $documents[(string) $id] = $this->identityMap->get($id);
+                $documents[$this->identityMap->idToString($id)] = $this->identityMap->get($id);
             }
         }
 
@@ -241,7 +241,7 @@ abstract class Repository
     {
         $ids = array();
         foreach ($mongoIds as $id) {
-            if (!isset($cachedDocuments[(string) $id])) {
+            if (!isset($cachedDocuments[$this->identityMap->idToString($id)])) {
                 $ids[] = $id;
             }
         }

--- a/tests/Mandango/Tests/IdentityMapTest.php
+++ b/tests/Mandango/Tests/IdentityMapTest.php
@@ -12,6 +12,8 @@
 namespace Mandango\Tests;
 
 use Mandango\IdentityMap;
+use MongoDB\BSON\ObjectID;
+use MongoDB\Model\BSONDocument;
 
 class IdentityMapTest extends TestCase
 {
@@ -62,5 +64,27 @@ class IdentityMapTest extends TestCase
         // clear
         $identityMap->clear();
         $this->assertSame(array(), $identityMap->all());
+    }
+
+    public function testIdToString()
+    {
+        $identityMap = new IdentityMap();
+
+        $id = $this->generateObjectId();
+        $this->assertEquals($id, $identityMap->idToString(new ObjectID($id)));
+
+        $idAsArray = ['a' => 1, 'b' => 2];
+        $this->assertEquals(json_encode($idAsArray), $identityMap->idToString(new BSONDocument($idAsArray)));
+
+        $idAsArray = ['a' => 1, 'b' => 2];
+        $this->assertEquals(json_encode($idAsArray), $identityMap->idToString($idAsArray));
+    }
+
+    public function testExceptionIdToString()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $identityMap = new IdentityMap();
+        $identityMap->idToString(new \DateTime());
     }
 }

--- a/tests/Mandango/Tests/RepositoryTest.php
+++ b/tests/Mandango/Tests/RepositoryTest.php
@@ -235,6 +235,21 @@ class RepositoryTest extends TestCase
         $this->assertEquals($array1, $array2);
     }
 
+    public function testFindByIdWithIdAsArray()
+    {
+        $repository = $this->getRepository('Model\IdAsArray');
+        $documents = [
+            ['_id' => ['a' => 1, 'b' => 2], 'name' => 'first'],
+            ['_id' => ['a' => 1, 'b' => 3], 'name' => 'second'],
+        ];
+        $repository->getCollection()->insertMany($documents);
+
+        $results = $repository->findById([['a' => 1, 'b' => 2]]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($documents[0]['name'], $results[0]->getName());
+    }
+
     public function testCount()
     {
         $criteria = array('is_active' => false);

--- a/tests/Model/IdAsArray.php
+++ b/tests/Model/IdAsArray.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Model\IdAsArray document.
+ */
+class IdAsArray extends \Model\Base\IdAsArray
+{
+}

--- a/tests/Model/IdAsArrayQuery.php
+++ b/tests/Model/IdAsArrayQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Query of Model\IdAsArray document.
+ */
+class IdAsArrayQuery extends \Model\Base\IdAsArrayQuery
+{
+}

--- a/tests/Model/IdAsArrayRepository.php
+++ b/tests/Model/IdAsArrayRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Model;
+
+/**
+ * Repository of Model\IdAsArray document.
+ */
+class IdAsArrayRepository extends \Model\Base\IdAsArrayRepository
+{
+}

--- a/tests/config_classes.php
+++ b/tests/config_classes.php
@@ -347,6 +347,12 @@ return array(
             'commentsLocal' => array('class' => 'Model\Comment'),
         ),
     ),
+    'Model\IdAsArray' => array(
+        'idGenerator' => 'none',
+        'fields' => array(
+            'name' => 'string',
+        )
+    ),
     // id generators
     'Model\NoneIdGenerator' => array(
         'idGenerator' => 'none',


### PR DESCRIPTION
I've created IdentityMap::idToString method, because id can be array or MongoDB\Model\BSONDocument.

Also I suggest get rid of IdentityMap::allByReference, because we duplicate logic.
```php
$identityMap[$identityMapObject->idToString($data['_id'])] = $document;
//but we already have IdentityMap::set()
```
I think will not be reduced performance, if get rid of using array by reference